### PR TITLE
ci: use only a single label for Github Actions runners

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   pre-commit:
     if: ${{ github.server_url == 'https://github.cds.internal.unity3d.com' }}
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: unity-linux-runner
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -37,7 +37,7 @@ jobs:
   validate-meta-files:
     # Only run on GitHub Enterprise
     if: ${{ github.server_url == 'https://github.cds.internal.unity3d.com' }}
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: unity-linux-runner
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2


### PR DESCRIPTION
⚠️ **Important**: This PR must be merged. Without merging this PR your actions will no longer work once we are fully migrated. ⚠️

⚠️ **Note** ⚠️
If you are using the `self-hosted` label but are not expecting to use the PRE runners then you can ignore this PR, however it's recommended to make sure you use more than just **`self-hosted`** as a label to avoid running your jobs on the incorrect runners.

The PRE team are working on deploying a new version of Action Runner Controller which is used for our self hosted runners, this update switches
the runners to use a new RunnerSet feature which only allows for a single label to be used for each runner type. This new Action Runner Controller will
come with the ability to start a new runner for every job that is created meaning the scaling of runners will be much more dynamic and should improve
scaling during peak times.

This PR removes all other labels other than the `unity-linux-runner` or `unity-linux-runner-xlarge` labels.

If you DO NOT merge this PR your actions will **NO LONGER WORK** once we are fully migrated (the target date for shutting down the old runners is March 1st) to the new Action Runner Controller. It's safe to merge this PR before we have migrated as all existing runners have these labels.

If you require running your runs in a specific region, have any problems after merging or have other questions please reach out in [#devs-github-actions](https://unity.enterprise.slack.com/archives/C012G66N0BA) for help.

Note: Apologies for those who get this PR re-opened after closing, we found a couple of patterns that were missing from our batch and want to make sure those repos don't go without actions. You can safely close the PR as you did before.

[_Created by Sourcegraph batch change `danielh/arcv2_runs_on_campaign`._](https://sourcegraph.ds.unity3d.com/users/danielh/batch-changes/arcv2_runs_on_campaign)